### PR TITLE
Update cron dependency to 1.1.1 due to npm error to find 1.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "async": "2.1.4",
-    "cron": "1.1.10",
+    "cron": "1.2.1",
     "cheerio": "0.22.0",
     "underscore": "1.8.3",
     "memory-cache": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "async": "2.1.4",
-    "cron": "1.2.1",
+    "cron": "1.1.1",
     "cheerio": "0.22.0",
     "underscore": "1.8.3",
     "memory-cache": "0.1.6",


### PR DESCRIPTION
Error showed when I installed to test it with atlasboard:
```shell
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install" "--production" "/home/BCCFRA/garciar/projects/git/dashboard/packages/red6"
npm ERR! node v6.9.1
npm ERR! npm  v3.10.8
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: cron@1.1.10
npm ERR! notarget Valid install targets:
npm ERR! notarget 1.2.1, 1.2.0, 1.1.1, 1.1.0, 1.0.9, 1.0.8, 1.0.7, 1.0.6, 1.0.5, 1.0.4, 1.0.3, 1.0.2, 1.0.1, 1.0.0, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.3.0, 0.2.0, 0.1.3, 0.1.2, 0.1.1, 0.1.0
npm ERR! notarget 
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget 
npm ERR! notarget It was specified as a dependency of 'atlasboard-red6-package'
```

Then I check versioneye link on the projects and see the result that is not found:
* [Version Eye](https://www.versioneye.com/user/projects/55cda1099a2f09001c00001d)